### PR TITLE
Add MySQL connection support

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,16 @@ Create a `.env` file. Add or remove as your design solidifies.
 ```bash
 DISCORD_TOKEN=your_bot_token
 APPLICATION_ID=your_application_id
-GUILD_ID=primary_guild_id   # optional if global commands
-DATABASE_URL=postgres://user:pass@host:5432/dbname  # or sqlite path
+GUILD_ID=primary_guild_id          # optional if global commands
+
+# Database configuration (MySQL/MariaDB)
+DB_SERVER=host
+DB_PORT=3306
+DB_USER=username
+DB_PASS=super_secret_password
+DB_NAME=database_name              # optional if you connect without selecting a schema
+DB_POOL_LIMIT=5                    # optional, concurrent connections in the pool
+
 LOG_LEVEL=info
 PUBLIC_COMMANDS=true
+```

--- a/database.js
+++ b/database.js
@@ -1,0 +1,59 @@
+// database.js
+// Provides a reusable MySQL connection pool for the bot.
+
+const mysql = require('mysql2/promise');
+
+function parsePort(value) {
+  if (!value) return 3306;
+  const parsed = Number.parseInt(String(value), 10);
+  return Number.isFinite(parsed) ? parsed : 3306;
+}
+
+function parseLimit(value) {
+  if (!value) return 5;
+  const parsed = Number.parseInt(String(value), 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 5;
+}
+
+function buildConfig() {
+  const requiredVariables = ['DB_SERVER', 'DB_USER', 'DB_PASS'];
+  const missing = requiredVariables.filter(key => !process.env[key] || !process.env[key].trim());
+
+  if (missing.length) {
+    throw new Error(`Missing database environment variables: ${missing.join(', ')}`);
+  }
+
+  return {
+    host: process.env.DB_SERVER,
+    port: parsePort(process.env.DB_PORT),
+    user: process.env.DB_USER,
+    password: process.env.DB_PASS,
+    database: process.env.DB_NAME || undefined,
+    waitForConnections: true,
+    connectionLimit: parseLimit(process.env.DB_POOL_LIMIT),
+    queueLimit: 0
+  };
+}
+
+let pool;
+
+function getPool() {
+  if (!pool) {
+    pool = mysql.createPool(buildConfig());
+  }
+  return pool;
+}
+
+async function testConnection() {
+  const connection = await getPool().getConnection();
+  try {
+    await connection.ping();
+  } finally {
+    connection.release();
+  }
+}
+
+module.exports = {
+  getPool,
+  testConnection
+};

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 // index.js
 require('dotenv/config');
 const { Client, GatewayIntentBits, Events } = require('discord.js');
+const { testConnection } = require('./database');
 
 // Minimal intents: we just want to connect and exist
 const client = new Client({
@@ -19,8 +20,24 @@ if (!token) {
   process.exit(1);
 }
 
-// Log in using your token from .env
-client.login(token);
+async function bootstrap() {
+  try {
+    await testConnection();
+    console.log('Database connection established.');
+  } catch (err) {
+    console.error('Unable to connect to the database:', err.message);
+    process.exit(1);
+  }
+
+  try {
+    await client.login(token);
+  } catch (err) {
+    console.error('Failed to log into Discord:', err);
+    process.exit(1);
+  }
+}
+
+bootstrap();
 
 // Optional: keep things tidy
 process.on('unhandledRejection', err => console.error('Unhandled promise rejection:', err));

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "ISC",
       "dependencies": {
         "discord.js": "^14.22.1",
-        "dotenv": "^17.2.2"
+        "dotenv": "^17.2.2",
+        "mysql2": "^3.12.0"
       }
     },
     "node_modules/@discordjs/builders": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "license": "MIT",
   "dependencies": {
     "discord.js": "^14.22.1",
-    "dotenv": "^17.2.2"
+    "dotenv": "^17.2.2",
+    "mysql2": "^3.12.0"
   }
 }


### PR DESCRIPTION
## Summary
- add a reusable MySQL connection pool module and verify connectivity during startup
- load the database configuration from environment variables and fail fast when credentials are missing
- document the required MySQL settings and declare the mysql2 dependency

## Testing
- not run (network restrictions prevented installing the new dependency locally)


------
https://chatgpt.com/codex/tasks/task_b_68d824827ba4832d910d2f16e8e04ed2